### PR TITLE
Fix matplotlib 3.4+ compatibility: handle set_window_title deprecation

### DIFF
--- a/src/mewpy/visualization/plot.py
+++ b/src/mewpy/visualization/plot.py
@@ -289,7 +289,17 @@ class StreamingPlot:
         pause(0.01)
 
     def create_layout(self, dimension):
-        self.fig.canvas.set_window_title(self.plot_title)
+        # Set window title (handling matplotlib 3.4+ API change)
+        try:
+            # New API (matplotlib 3.4+)
+            self.fig.canvas.manager.set_window_title(self.plot_title)
+        except AttributeError:
+            # Old API or backend without window title support
+            try:
+                self.fig.canvas.set_window_title(self.plot_title)
+            except (AttributeError, TypeError):
+                # Some backends (e.g., nbagg) don't support window titles
+                pass
         self.fig.suptitle(self.plot_title, fontsize=16)
 
         if dimension == 2:


### PR DESCRIPTION
The set_window_title method was moved from canvas to canvas.manager in matplotlib 3.4+. Added graceful fallback handling:
1. Try new API: canvas.manager.set_window_title()
2. Fall back to old API: canvas.set_window_title()
3. Silently skip for backends without window title support (e.g., nbagg)

Fixes AttributeError: 'FigureCanvasNbAgg' object has no attribute 'set_window_title'